### PR TITLE
feat: Implement shared text selections

### DIFF
--- a/index.html
+++ b/index.html
@@ -210,6 +210,7 @@
                     this.localVersion = 0;
                     this.pendingOperations = [];
                     this.isApplyingRemoteChange = false;
+                    this.remoteSelections = {}; // Added this line
 
                     this.initializeEditor();
                     this.initializeWebSocket();
@@ -244,7 +245,32 @@
                 // Handle cursor changes
                 this.editor.on('cursorActivity', () => {
                     if (this.isApplyingRemoteChange) return;
-                    this.sendCursorPosition();
+
+                    if (this.editor.somethingSelected()) {
+                        const startPos = this.editor.getCursor('start');
+                        const endPos = this.editor.getCursor('end');
+                        const selectionStart = this.editor.indexFromPos(startPos);
+                        const selectionEnd = this.editor.indexFromPos(endPos);
+
+                        this.sendOperation({
+                            type: 'selection',
+                            selectionStart: selectionStart,
+                            selectionEnd: selectionEnd,
+                            clientId: this.clientId
+                        });
+                    } else {
+                        // Send regular cursor position if no selection
+                        this.sendCursorPosition();
+
+                        // Also send a "clear selection" message for this client if they previously had one.
+                        // This ensures remote highlights are removed when selection is cleared locally.
+                         this.sendOperation({
+                            type: 'selection',
+                            selectionStart: this.editor.indexFromPos(this.editor.getCursor()), // current cursor pos
+                            selectionEnd: this.editor.indexFromPos(this.editor.getCursor()),   // same as start
+                            clientId: this.clientId
+                        });
+                    }
                 });
             }
 
@@ -377,6 +403,14 @@
 
                             case 'cursor':
                                 this.updateRemoteCursor(operation.clientId, operation.position);
+                                // Potentially clear any selection from this client if we receive a cursor update
+                                if (this.remoteSelections[operation.clientId]) {
+                                    this.remoteSelections[operation.clientId].clear();
+                                    delete this.remoteSelections[operation.clientId];
+                                }
+                                break;
+                            case 'selection':
+                                this.updateRemoteSelection(operation.clientId, operation.selectionStart, operation.selectionEnd);
                                 break;
                         }
                     } finally {
@@ -420,6 +454,29 @@
                         cursor.remove();
                     }
                 }, 3000);
+                }
+
+                updateRemoteSelection(clientId, selectionStart, selectionEnd) {
+                    // Don't show our own selection mirrored back
+                    if (clientId === this.clientId) return;
+
+                    // Clear existing selection for this client
+                    if (this.remoteSelections[clientId]) {
+                        this.remoteSelections[clientId].clear();
+                        delete this.remoteSelections[clientId];
+                    }
+
+                    // If selectionStart and selectionEnd are different, it's a new selection
+                    if (selectionStart !== selectionEnd) {
+                        const fromPos = this.editor.posFromIndex(selectionStart);
+                        const toPos = this.editor.posFromIndex(selectionEnd);
+                        const color = this.getClientColor(clientId);
+
+                        this.remoteSelections[clientId] = this.editor.markText(fromPos, toPos, {
+                            css: `background-color: ${color}; opacity: 0.5;`, // Example styling
+                            title: clientId // Show client ID on hover (optional)
+                        });
+                    }
             }
 
                 getClientColor(clientId) {

--- a/main.go
+++ b/main.go
@@ -16,6 +16,8 @@ type Operation struct {
 	Position int    `json:"position"`
 	Text     string `json:"text,omitempty"`
 	Length   int    `json:"length,omitempty"`
+	SelectionStart int `json:"selectionStart,omitempty"`
+	SelectionEnd   int `json:"selectionEnd,omitempty"`
 	Version  int    `json:"version"`
 	ClientID string `json:"clientId"`
 }


### PR DESCRIPTION
This commit introduces real-time sharing of text selections between connected clients in the collaborative editor.

Key changes include:

Backend (`main.go`):
- Extended the `Operation` struct to include `SelectionStart` and `SelectionEnd` fields to transport selection range information.
- The existing WebSocket broadcasting logic now relays these selection details to other clients.

Frontend (`index.html` - JavaScript):
- Added logic to detect local text selections in the CodeMirror editor.
- When a selection is made or changed, a `selection` operation is sent to the server, including the start and end indices of the selection.
- When a selection is cleared locally, an operation is sent to inform other clients.
- Implemented `updateRemoteSelection` to handle incoming `selection` operations:
    - It uses CodeMirror's `markText()` to visually highlight the text range selected by other users.
    - Each user's selection is displayed with a unique color for easy identification.
    - Existing selections are cleared or updated as new selection information is received.
- Remote selections are also cleared if a standard cursor update is received from a client, implying they are no longer actively selecting a range.

This feature enhances the collaborative experience by allowing you to see what parts of the document others are focusing on or highlighting.

Note: Advanced transformation of selection ranges during concurrent edits is not included in this initial implementation. Selections might temporarily appear desynchronized if the document is modified simultaneously by multiple users at different locations.